### PR TITLE
Add initial Flask ticketing system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+uploads/
+instance/
+.mypy_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # Tick-It
-An IT system for higher ed.
+
+A simple IT ticketing and inventory system built with Flask and SQLite.
+
+## Setup
+
+Create a Python virtual environment and install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Initialize the database:
+
+```bash
+flask db init
+flask db migrate -m "init"
+flask db upgrade
+```
+
+Run the application:
+
+```bash
+python run.py
+```
+
+The API will be available at `http://localhost:5000/api/`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+
+
+db = SQLAlchemy()
+migrate = Migrate()
+
+
+def create_app(config_object='app.config.Config'):
+    app = Flask(__name__)
+    app.config.from_object(config_object)
+
+    db.init_app(app)
+    migrate.init_app(app, db)
+
+    from . import routes
+    app.register_blueprint(routes.bp)
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,8 @@
+import os
+
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///tickit.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    UPLOAD_FOLDER = os.environ.get('UPLOAD_FOLDER', 'uploads')

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,190 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+from . import db
+
+
+# Association tables
+
+deliverable_assets = db.Table(
+    'deliverable_assets',
+    db.Column('deliverable_id', db.Integer, db.ForeignKey('deliverable.id'), primary_key=True),
+    db.Column('asset_id', db.Integer, db.ForeignKey('asset.id'), primary_key=True)
+)
+
+deliverable_rooms = db.Table(
+    'deliverable_rooms',
+    db.Column('deliverable_id', db.Integer, db.ForeignKey('deliverable.id'), primary_key=True),
+    db.Column('room_id', db.Integer, db.ForeignKey('room.id'), primary_key=True)
+)
+
+deliverable_technicians = db.Table(
+    'deliverable_technicians',
+    db.Column('deliverable_id', db.Integer, db.ForeignKey('deliverable.id'), primary_key=True),
+    db.Column('technician_id', db.Integer, db.ForeignKey('technician.id'), primary_key=True)
+)
+
+action_assets = db.Table(
+    'action_assets',
+    db.Column('action_id', db.Integer, db.ForeignKey('action.id'), primary_key=True),
+    db.Column('asset_id', db.Integer, db.ForeignKey('asset.id'), primary_key=True)
+)
+
+action_rooms = db.Table(
+    'action_rooms',
+    db.Column('action_id', db.Integer, db.ForeignKey('action.id'), primary_key=True),
+    db.Column('room_id', db.Integer, db.ForeignKey('room.id'), primary_key=True)
+)
+
+action_technicians = db.Table(
+    'action_technicians',
+    db.Column('action_id', db.Integer, db.ForeignKey('action.id'), primary_key=True),
+    db.Column('technician_id', db.Integer, db.ForeignKey('technician.id'), primary_key=True)
+)
+
+action_files = db.Table(
+    'action_files',
+    db.Column('action_id', db.Integer, db.ForeignKey('action.id'), primary_key=True),
+    db.Column('file_id', db.Integer, db.ForeignKey('file.id'), primary_key=True)
+)
+
+action_comments = db.Table(
+    'action_comments',
+    db.Column('action_id', db.Integer, db.ForeignKey('action.id'), primary_key=True),
+    db.Column('comment_id', db.Integer, db.ForeignKey('comment.id'), primary_key=True)
+)
+
+deliverable_files = db.Table(
+    'deliverable_files',
+    db.Column('deliverable_id', db.Integer, db.ForeignKey('deliverable.id'), primary_key=True),
+    db.Column('file_id', db.Integer, db.ForeignKey('file.id'), primary_key=True)
+)
+
+deliverable_comments = db.Table(
+    'deliverable_comments',
+    db.Column('deliverable_id', db.Integer, db.ForeignKey('deliverable.id'), primary_key=True),
+    db.Column('comment_id', db.Integer, db.ForeignKey('comment.id'), primary_key=True)
+)
+
+
+class Technician(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(64), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='tech')
+
+    deliverables = db.relationship('Deliverable', secondary=deliverable_technicians, back_populates='technicians')
+    actions = db.relationship('Action', secondary=action_technicians, back_populates='technicians')
+
+
+class Contact(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    requester_name = db.Column(db.String(120))
+    requester_email = db.Column(db.String(120))
+    requester_phone = db.Column(db.String(50))
+    message = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    deliverables = db.relationship('Deliverable', back_populates='contact', cascade='all, delete-orphan')
+
+    @property
+    def code(self):
+        return f"CON{self.id:07d}"
+
+
+class Deliverable(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(120))
+    description = db.Column(db.Text)
+    priority = db.Column(db.String(20))
+    status = db.Column(db.String(20), default='Pending')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'))
+
+    contact = db.relationship('Contact', back_populates='deliverables')
+    actions = db.relationship('Action', back_populates='deliverable', cascade='all, delete-orphan')
+    assets = db.relationship('Asset', secondary=deliverable_assets, back_populates='deliverables')
+    rooms = db.relationship('Room', secondary=deliverable_rooms, back_populates='deliverables')
+    technicians = db.relationship('Technician', secondary=deliverable_technicians, back_populates='deliverables')
+    files = db.relationship('File', secondary=deliverable_files, back_populates='deliverables')
+    comments = db.relationship('Comment', secondary=deliverable_comments, back_populates='deliverables')
+
+    @property
+    def code(self):
+        return f"DEL{self.id:07d}"
+
+
+class Action(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(db.Text)
+    status = db.Column(db.String(20), default='To Do')
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    deliverable_id = db.Column(db.Integer, db.ForeignKey('deliverable.id'))
+
+    deliverable = db.relationship('Deliverable', back_populates='actions')
+    assets = db.relationship('Asset', secondary=action_assets, back_populates='actions')
+    rooms = db.relationship('Room', secondary=action_rooms, back_populates='actions')
+    technicians = db.relationship('Technician', secondary=action_technicians, back_populates='actions')
+    files = db.relationship('File', secondary=action_files, back_populates='actions')
+    comments = db.relationship('Comment', secondary=action_comments, back_populates='actions')
+
+    @property
+    def code(self):
+        return f"ACT{self.id:07d}"
+
+
+class Asset(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120))
+    type = db.Column(db.String(120))
+    model = db.Column(db.String(120))
+    manufacturer = db.Column(db.String(120))
+    serial_number = db.Column(db.String(120))
+    purchase_date = db.Column(db.Date)
+    warranty_info = db.Column(db.String(120))
+
+    assigned_user_id = db.Column(db.Integer, db.ForeignKey('technician.id'))
+    assigned_room_id = db.Column(db.Integer, db.ForeignKey('room.id'))
+
+    assigned_user = db.relationship('Technician', foreign_keys=[assigned_user_id])
+    assigned_room = db.relationship('Room', foreign_keys=[assigned_room_id])
+
+    deliverables = db.relationship('Deliverable', secondary=deliverable_assets, back_populates='assets')
+    actions = db.relationship('Action', secondary=action_assets, back_populates='assets')
+
+
+class Room(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    building = db.Column(db.String(120))
+    room_number = db.Column(db.String(120))
+    description = db.Column(db.Text)
+
+    assets = db.relationship('Asset', back_populates='assigned_room', cascade='all, delete')
+    deliverables = db.relationship('Deliverable', secondary=deliverable_rooms, back_populates='rooms')
+    actions = db.relationship('Action', secondary=action_rooms, back_populates='rooms')
+
+
+class File(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(255))
+    path = db.Column(db.String(255))
+    mime_type = db.Column(db.String(120))
+    uploaded_at = db.Column(db.DateTime, default=datetime.utcnow)
+    uploaded_by_id = db.Column(db.Integer, db.ForeignKey('technician.id'))
+
+    uploaded_by = db.relationship('Technician')
+    deliverables = db.relationship('Deliverable', secondary=deliverable_files, back_populates='files')
+    actions = db.relationship('Action', secondary=action_files, back_populates='files')
+
+
+class Comment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.Text)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('technician.id'))
+
+    user = db.relationship('Technician')
+    deliverables = db.relationship('Deliverable', secondary=deliverable_comments, back_populates='comments')
+    actions = db.relationship('Action', secondary=action_comments, back_populates='comments')

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,188 @@
+from flask import Blueprint, request, jsonify, current_app, send_from_directory
+from .models import db, Technician, Contact, Deliverable, Action, Asset, Room, File, Comment
+from werkzeug.utils import secure_filename
+import os
+
+bp = Blueprint('api', __name__, url_prefix='/api')
+
+# Helper to save uploaded file
+
+def save_file(uploaded_file, uploaded_by):
+    filename = secure_filename(uploaded_file.filename)
+    upload_folder = current_app.config['UPLOAD_FOLDER']
+    os.makedirs(upload_folder, exist_ok=True)
+    filepath = os.path.join(upload_folder, filename)
+    uploaded_file.save(filepath)
+    f = File(filename=filename, path=filepath, mime_type=uploaded_file.mimetype, uploaded_by=uploaded_by)
+    db.session.add(f)
+    return f
+
+@bp.route('/contacts', methods=['GET'])
+def list_contacts():
+    contacts = Contact.query.all()
+    result = []
+    for c in contacts:
+        result.append({'id': c.code, 'requester_name': c.requester_name, 'created_at': c.created_at.isoformat(), 'deliverable_count': len(c.deliverables)})
+    return jsonify(result)
+
+@bp.route('/contacts', methods=['POST'])
+def create_contact():
+    data = request.get_json()
+    c = Contact(
+        requester_name=data.get('requester_name'),
+        requester_email=data.get('requester_email'),
+        requester_phone=data.get('requester_phone'),
+        message=data.get('message')
+    )
+    db.session.add(c)
+    db.session.commit()
+    return jsonify({'id': c.code, 'created_at': c.created_at.isoformat()}), 201
+
+@bp.route('/contacts/<int:contact_id>', methods=['GET'])
+def get_contact(contact_id):
+    c = Contact.query.get_or_404(contact_id)
+    deliverables = [{'id': d.code, 'title': d.title, 'status': d.status} for d in c.deliverables]
+    return jsonify({'id': c.code, 'requester_name': c.requester_name, 'deliverables': deliverables})
+
+@bp.route('/contacts/<int:contact_id>/deliverables', methods=['POST'])
+def add_deliverable(contact_id):
+    c = Contact.query.get_or_404(contact_id)
+    data = request.get_json()
+    d = Deliverable(title=data.get('title'), description=data.get('description'), priority=data.get('priority'), status=data.get('status'))
+    c.deliverables.append(d)
+    db.session.add(d)
+    db.session.commit()
+    return jsonify({'id': d.code, 'title': d.title, 'status': d.status}), 201
+
+@bp.route('/deliverables/<int:deliverable_id>', methods=['GET'])
+def get_deliverable(deliverable_id):
+    d = Deliverable.query.get_or_404(deliverable_id)
+    actions = [{'id': a.code, 'description': a.description, 'status': a.status} for a in d.actions]
+    return jsonify({'id': d.code, 'title': d.title, 'status': d.status, 'priority': d.priority, 'actions': actions})
+
+@bp.route('/deliverables/<int:deliverable_id>', methods=['PATCH'])
+def update_deliverable(deliverable_id):
+    d = Deliverable.query.get_or_404(deliverable_id)
+    data = request.get_json()
+    if 'status' in data:
+        d.status = data['status']
+    if 'title' in data:
+        d.title = data['title']
+    db.session.commit()
+    return jsonify({'id': d.code, 'status': d.status})
+
+@bp.route('/deliverables/<int:deliverable_id>/actions', methods=['POST'])
+def create_action(deliverable_id):
+    d = Deliverable.query.get_or_404(deliverable_id)
+    data = request.get_json()
+    a = Action(description=data.get('description'), status=data.get('status'))
+    d.actions.append(a)
+    db.session.add(a)
+    db.session.commit()
+    return jsonify({'id': a.code, 'description': a.description, 'status': a.status}), 201
+
+@bp.route('/actions/<int:action_id>', methods=['PATCH'])
+def update_action(action_id):
+    a = Action.query.get_or_404(action_id)
+    data = request.get_json()
+    if 'status' in data:
+        a.status = data['status']
+    if 'description' in data:
+        a.description = data['description']
+    if 'assigned_technician_id' in data:
+        tech = Technician.query.get(data['assigned_technician_id'])
+        if tech:
+            if tech not in a.technicians:
+                a.technicians.append(tech)
+    db.session.commit()
+    return jsonify({'id': a.code, 'status': a.status})
+
+@bp.route('/assets', methods=['GET'])
+def list_assets():
+    assets = Asset.query.all()
+    result = []
+    for asset in assets:
+        result.append({'id': asset.id, 'name': asset.name, 'type': asset.type, 'assigned_user_id': asset.assigned_user_id, 'assigned_room_id': asset.assigned_room_id})
+    return jsonify(result)
+
+@bp.route('/assets', methods=['POST'])
+def create_asset():
+    data = request.get_json()
+    asset = Asset(
+        name=data.get('name'),
+        type=data.get('type'),
+        model=data.get('model'),
+        manufacturer=data.get('manufacturer'),
+        serial_number=data.get('serial_number'),
+        purchase_date=data.get('purchase_date'),
+        warranty_info=data.get('warranty_info'),
+        assigned_user_id=data.get('assigned_user_id'),
+        assigned_room_id=data.get('assigned_room_id')
+    )
+    db.session.add(asset)
+    db.session.commit()
+    return jsonify({'id': asset.id, 'name': asset.name}), 201
+
+@bp.route('/assets/<int:asset_id>', methods=['PATCH'])
+def update_asset(asset_id):
+    asset = Asset.query.get_or_404(asset_id)
+    data = request.get_json()
+    for field in ['name', 'type', 'model', 'manufacturer', 'serial_number', 'warranty_info']:
+        if field in data:
+            setattr(asset, field, data[field])
+    if 'assigned_user_id' in data:
+        asset.assigned_user_id = data['assigned_user_id']
+    if 'assigned_room_id' in data:
+        asset.assigned_room_id = data['assigned_room_id']
+    db.session.commit()
+    return jsonify({'id': asset.id})
+
+@bp.route('/rooms', methods=['GET'])
+def list_rooms():
+    rooms = Room.query.all()
+    return jsonify([{'id': r.id, 'building': r.building, 'room_number': r.room_number} for r in rooms])
+
+@bp.route('/rooms', methods=['POST'])
+def create_room():
+    data = request.get_json()
+    room = Room(building=data.get('building'), room_number=data.get('room_number'), description=data.get('description'))
+    db.session.add(room)
+    db.session.commit()
+    return jsonify({'id': room.id}), 201
+
+@bp.route('/comments', methods=['POST'])
+def create_comment():
+    data = request.get_json()
+    comment = Comment(content=data['content'], user_id=data.get('user_id'))
+    parent_type = data.get('parent_type')
+    parent_id = data.get('parent_id')
+    if parent_type == 'Deliverable':
+        deliverable = Deliverable.query.get_or_404(parent_id)
+        deliverable.comments.append(comment)
+    elif parent_type == 'Action':
+        action = Action.query.get_or_404(parent_id)
+        action.comments.append(comment)
+    db.session.add(comment)
+    db.session.commit()
+    return jsonify({'id': comment.id}), 201
+
+@bp.route('/files', methods=['POST'])
+def upload_file():
+    uploaded_file = request.files['file']
+    parent_type = request.form.get('parent_type')
+    parent_id = request.form.get('parent_id')
+    uploaded_by_id = request.form.get('uploaded_by_id')
+    tech = Technician.query.get(uploaded_by_id) if uploaded_by_id else None
+    f = save_file(uploaded_file, tech)
+    if parent_type == 'Deliverable':
+        deliverable = Deliverable.query.get_or_404(parent_id)
+        deliverable.files.append(f)
+    elif parent_type == 'Action':
+        action = Action.query.get_or_404(parent_id)
+        action.files.append(f)
+    db.session.commit()
+    return jsonify({'id': f.id, 'filename': f.filename})
+
+@bp.route('/uploads/<path:filename>')
+def uploaded_file(filename):
+    return send_from_directory(current_app.config['UPLOAD_FOLDER'], filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-SQLAlchemy
+Flask-Migrate
+Werkzeug

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- initialize Flask app with SQLAlchemy models
- implement CRUD API routes for contacts, deliverables, actions, assets, rooms, comments, and files
- add run script, dependencies, and setup instructions
- clean up compiled caches and add `.gitignore`

## Testing
- `python -m py_compile app/__init__.py app/config.py app/models.py app/routes.py run.py`

------
https://chatgpt.com/codex/tasks/task_e_686be75c507c832db7b1ee91ee3ecbf5